### PR TITLE
Add basic phone tree Flask app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+static/generated.mp3

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# a4c-phone-tree
+# A4C Phone Tree
+
+Simple Flask application demonstrating a phone tree that uses ChatGPT to draft a message, ElevenLabs to generate audio, and Twilio to deliver SMS and voice calls.
+
+## Setup
+
+1. Install dependencies:
+
+```
+pip install -r requirements.txt
+```
+
+2. Export required credentials:
+
+```
+export OPENAI_API_KEY=your_openai_key
+export ELEVENLABS_API_KEY=your_elevenlabs_key
+export TWILIO_SID=your_twilio_sid
+export TWILIO_AUTH_TOKEN=your_twilio_auth_token
+export TWILIO_NUMBER=+15551234567
+```
+
+3. Adjust the recipient lists in `app.py` (`RECIPIENT_SMS` and `RECIPIENT_CALL`).
+
+4. Run the app:
+
+```
+python app.py
+```
+
+The application will be available at `http://localhost:5000`.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,68 @@
+import os
+from flask import Flask, render_template, request, url_for, Response
+import openai
+import requests
+from twilio.rest import Client
+
+app = Flask(__name__)
+AUDIO_FILE = 'static/generated.mp3'
+
+openai.api_key = os.environ.get('OPENAI_API_KEY')
+ELEVEN_API_KEY = os.environ.get('ELEVENLABS_API_KEY')
+TWILIO_SID = os.environ.get('TWILIO_SID')
+TWILIO_AUTH = os.environ.get('TWILIO_AUTH_TOKEN')
+TWILIO_NUMBER = os.environ.get('TWILIO_NUMBER')
+
+client = Client(TWILIO_SID, TWILIO_AUTH)
+
+RECIPIENT_SMS = ['+15551234567']
+RECIPIENT_CALL = ['+15557654321']
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if request.method == 'POST':
+        prompt = request.form['message']
+        completion = openai.ChatCompletion.create(
+            model='gpt-4o-mini',
+            messages=[{'role': 'user', 'content': prompt}]
+        )
+        text = completion['choices'][0]['message']['content'].strip()
+        audio_bytes = generate_audio(text)
+        with open(AUDIO_FILE, 'wb') as f:
+            f.write(audio_bytes)
+        return render_template('approve.html', text=text, audio=url_for('static', filename='generated.mp3'))
+    return render_template('index.html')
+
+
+def generate_audio(text: str) -> bytes:
+    resp = requests.post(
+        'https://api.elevenlabs.io/v1/text-to-speech/EXAVITQu4vr4xnSDxMaL',
+        headers={
+            'xi-api-key': ELEVEN_API_KEY,
+            'Content-Type': 'application/json'
+        },
+        json={'text': text}
+    )
+    return resp.content
+
+
+@app.route('/send', methods=['POST'])
+def send():
+    text = request.form['text']
+    for to in RECIPIENT_SMS:
+        client.messages.create(body=text, from_=TWILIO_NUMBER, to=to)
+    twiml_url = url_for('twiml', _external=True)
+    for to in RECIPIENT_CALL:
+        client.calls.create(to=to, from_=TWILIO_NUMBER, url=twiml_url)
+    return 'Messages sent.'
+
+
+@app.route('/twiml', methods=['GET', 'POST'])
+def twiml():
+    audio_url = url_for('static', filename='generated.mp3', _external=True)
+    xml = f"<?xml version='1.0' encoding='UTF-8'?><Response><Play>{audio_url}</Play></Response>"
+    return Response(xml, mimetype='text/xml')
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000, debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask
+openai
+requests
+twilio

--- a/templates/approve.html
+++ b/templates/approve.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+<head>
+  <title>Approve Message</title>
+</head>
+<body>
+  <h1>Approve Message</h1>
+  <p>{{ text }}</p>
+  <audio controls src="{{ audio }}"></audio>
+  <form action="{{ url_for('send') }}" method="post">
+    <input type="hidden" name="text" value="{{ text }}">
+    <button type="submit">Send</button>
+  </form>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+<head>
+  <title>Phone Tree</title>
+</head>
+<body>
+  <h1>Create Phone Tree Message</h1>
+  <form method="post">
+    <textarea name="message" rows="4" cols="50" placeholder="Enter message"></textarea><br>
+    <button type="submit">Generate</button>
+  </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build Flask server that drafts messages with ChatGPT, creates audio with ElevenLabs, and delivers SMS/voice via Twilio
- provide simple HTML templates for message entry and approval
- document setup and dependencies

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6894ec7d1ab48324b32349fc117b9bac